### PR TITLE
fix: prevent `ArrayIndexOutOfBoundsException` on sections construct

### DIFF
--- a/src/main/java/jromp/parallel/Parallel.java
+++ b/src/main/java/jromp/parallel/Parallel.java
@@ -228,20 +228,13 @@ public class Parallel {
 	 * @return The parallel execution block.
 	 */
 	public Parallel sections(Variables variables, Task... tasks) {
-		this.variables = variables;
-		addNumThreadsToVariables(this.variables);
-		this.variablesList.add(this.variables);
+		List<Section> sections = new ArrayList<>();
 
-		for (int i = 0; i < this.threads; i++) {
-			final int finalI = i;
-			Task task = tasks[i];
-			Variables vars = variables.copy();
-			this.variablesList.add(vars);
-
-			threadExecutor.execute(() -> task.run(finalI, vars));
+		for (Task task : tasks) {
+			sections.add(new Section(task, variables));
 		}
 
-		return this;
+		return this.sections(sections.toArray(Section[]::new));
 	}
 
 	/**

--- a/src/test/java/jromp/parallel/ParallelTests.java
+++ b/src/test/java/jromp/parallel/ParallelTests.java
@@ -68,6 +68,38 @@ class ParallelTests {
 	}
 
 	@Test
+	void testSections() {
+		int[] result = new int[4];
+
+		Parallel.withThreads(4)
+		        .sections(
+				        (id, vars) -> result[id] = 1,
+				        (id, vars) -> result[id] = 2,
+				        (id, vars) -> result[id] = 3,
+				        (id, vars) -> result[id] = 4
+		        )
+		        .join();
+
+		assertThat(result).containsOnly(1, 2, 3, 4);
+	}
+
+	@Test
+	void testSectionsMoreThreadsThanSections() {
+		int threads = 4;
+		int[] result = new int[threads];
+
+		Parallel.withThreads(threads)
+		        .sections(
+				        (id, vars) -> result[id] = 1,
+				        (id, vars) -> result[id] = 2,
+				        (id, vars) -> result[id] = 3
+		        )
+		        .join();
+
+		assertThat(result).containsOnly(1, 2, 3, 0);
+	}
+
+	@Test
 	void testParallelBlockWithDefaultVariables() {
 		int threads = 4;
 		int iterations = 1000;

--- a/src/test/java/jromp/parallel/var/LastPrivateVariableTest.java
+++ b/src/test/java/jromp/parallel/var/LastPrivateVariableTest.java
@@ -98,7 +98,7 @@ class LastPrivateVariableTest {
 				        // The master thread will sleep for a while to end up with a different value
 				        if (Utils.isMaster(id)) {
 					        try {
-						        Thread.sleep(5);
+						        Thread.sleep(100);
 					        } catch (InterruptedException e) {
 						        throw new RuntimeException(e);
 					        }


### PR DESCRIPTION
<!-- ☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->
<!-- Thanks for taking the time to write this Pull Request! ❤️ -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, README or JSdoc annotations).
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue).
- [ ] 👌 Enhancement (improving an existing functionality like performance).
- [ ] ✨ New feature (a non-breaking change that adds functionality).
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries).
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change).

### 📚 Description, Motivation and Context

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Resolves #13.

### 🧪 How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- Your change affects other areas of the code, etc. -->

New test cases have been added that cover the specific case where there are more threads than sections to run. All of them run and pass successfully.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
